### PR TITLE
Reduce .NET version to 2.0

### DIFF
--- a/ConvertCSS.cs
+++ b/ConvertCSS.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-using System.IO;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 
 namespace TextureConverter
 {
@@ -20,7 +16,7 @@ namespace TextureConverter
             info.UseShellExecute = true;
             info.WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
-            string VTFCmd = Path.Combine(info.WorkingDirectory, "vtflib", "VTFCmd.exe");
+            string VTFCmd = Path.Combine(info.WorkingDirectory, Path.Combine("vtflib", "VTFCmd.exe"));
             string output = Path.Combine(info.WorkingDirectory, "temp");
 
             info.FileName = "cmd"; info.Arguments = "/C " + VTFCmd + " -file \"" + files[0] + "\" -output \"" + output + "\" -exportformat \"png\"";

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,14 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 using System.IO;
-using System.Diagnostics;
+using System.Windows.Forms;
 
 namespace TextureConverter
 {

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace TextureConverter

--- a/TextureConverter.csproj
+++ b/TextureConverter.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>TextureConverter</RootNamespace>
     <AssemblyName>TextureConverter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
It's absolutely ultra critical it runs on windows 98.

Jokes aside, XP doesn't support .NET 4.5+ asides from via Mono